### PR TITLE
fix(generator): exporting text-based asset files does not work correctly on Windows

### DIFF
--- a/src/hexo/generator/assets.js
+++ b/src/hexo/generator/assets.js
@@ -41,7 +41,7 @@ module.exports = function(hexo) {
                 return null;
             }
             return {
-                path: encodeURI('/' + path.relative(assetsDir, file)),
+                path: encodeURI('/' + filepath.replace(/\\/g, '/')),
                 data: fs.readFileSync(file, { encoding: 'utf-8' })
             };
         }).filter(file => file !== null);


### PR DESCRIPTION
### Issue

Assets files path are incorrect when running `hexo g`

![Untitled](https://user-images.githubusercontent.com/20182252/76727553-5444ca00-678f-11ea-94ac-c937708b4fea.png)

Test failed

![Before](https://user-images.githubusercontent.com/20182252/76729530-552c2a80-6794-11ea-989d-47da7823f2a7.png)

### How to fix

Replace `\` with `/` in path. Test passed.

![After](https://user-images.githubusercontent.com/20182252/76729546-578e8480-6794-11ea-9dce-4fd7d8cd8eb1.png)