### PR TITLE
fix(generator): should not encode assets file path

### DIFF
--- a/src/hexo/generator/assets.js
+++ b/src/hexo/generator/assets.js
@@ -41,7 +41,7 @@ module.exports = function(hexo) {
                 return null;
             }
             return {
-                path: encodeURI('/' + filepath.replace(/\\/g, '/')),
+                path: '/' + filepath.replace(/\\/g, '/'),
                 data: fs.readFileSync(file, { encoding: 'utf-8' })
             };
         }).filter(file => file !== null);

--- a/src/hexo/generator/assets.test.js
+++ b/src/hexo/generator/assets.test.js
@@ -18,7 +18,7 @@ test('Export files from asset/ folder that are not in theme\'s source folder', a
     const generator = hexo.extend.generator.get('static_assets').bind(hexo);
     const result = await generator(locals);
     ['/js/algolia.js', '/js/google_cse.js'].forEach(file => {
-        expect(result.find(route => route.path === file)).not.toBeNull();
+        expect(result.find(route => route.path === file)).not.toBeUndefined();
         expect(result.find(route => route.path === file).data)
             .toBe(readFileSync(join(assetsDir, file), { encoding: 'utf-8' }));
     });


### PR DESCRIPTION
### Issue

If we create "hexo-component-inferno/assets/js/some file.js", then hexo g, Hexo generator will generate a file named "public/js/some%20file.js", then we push it to web host, the file's URL should be "https://[host]/js/some%2520file.js", that's not what we wish.

### How to fix

Not to encode assets file path.

### Test result

![Test](https://user-images.githubusercontent.com/20182252/76813908-59a82000-6834-11ea-8a40-900532f62682.png)