### PR TITLE
fix: quote problem

### DIFF
--- a/src/view/comment/disqusjs.jsx
+++ b/src/view/comment/disqusjs.jsx
@@ -50,8 +50,8 @@ class DisqusJs extends Component {
         }
         const js = `new DisqusJS({
             shortname: '${shortname}',
-            apikey: '${JSON.stringify(apiKey)}',
-            siteName: '${siteTitle}',
+            apikey: ${JSON.stringify(apiKey)},
+            siteName: "${siteTitle}",
             identifier: '${disqusId || path}',
             url: '${permalink || path}',
             title: '${pageTitle}',


### PR DESCRIPTION
fix `apiKey` quote problem, like `'"aaa"'`
fix blog title with `'`, like `someone's blog`
PS: Technically there will be problems when there're double quotes in `siteTitle`; Also, article title has the same problem, but I haven't come up with a satisfying solution.