### PR TITLE
feat(view): fix #17, and make article_licensing supports more than one icons

### DIFF
--- a/src/schema/misc/poly_links.json
+++ b/src/schema/misc/poly_links.json
@@ -13,7 +13,7 @@
           "description": "URL or path of the link"
         },
         "icon": {
-          "type": "string",
+          "type": ["string", "array"],
           "description": "Icon element class name"
         }
       },

--- a/src/schema/widget/links.json
+++ b/src/schema/widget/links.json
@@ -13,8 +13,25 @@
       "description": "Names and URLs of the sites",
       "patternProperties": {
         ".+": {
-          "type": "string",
-          "description": "URL of the site"
+          "anyOf": [
+            {
+              "type": "string",
+              "description": "URL of the site"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "link": {
+                  "type": "string",
+                  "description": "URL of the site"
+                },
+                "hide_hostname": {
+                  "type": "boolean",
+                  "description": "Whether remove righthand hostname tag from the menu"
+                }
+              }
+            }
+          ]
         }
       },
       "examples": [

--- a/src/view/misc/article_licensing.jsx
+++ b/src/view/misc/article_licensing.jsx
@@ -23,8 +23,8 @@ const { cacheComponent } = require('../../util/cache');
  *             url: 'https://creativecommons.org/'
  *         },
  *         'Attribution 4.0 International': {
- *             icon: 'fab fa-creative-commons-by',
- *             url: 'https://creativecommons.org/licenses/by/4.0/'
+ *             icon: ['fab fa-creative-commons-by', 'fab fa-creative-commons-nc'],
+ *             url: 'https://creativecommons.org/licenses/by-nc/4.0/'
  *         },
  *     }}
  *     licensedTitle="Licensed under" />
@@ -87,9 +87,17 @@ class ArticleLicensing extends Component {
                         rel="noopener"
                         target="_blank"
                         title={name}
-                        class={licenses[name].icon ? 'icon' : ''}
+                        class={licenses[name].icon ? 'icons' : ''}
                         href={licenses[name].url}>
-                        {licenses[name].icon ? <i class={licenses[name].icon}></i> : name}
+                        {licenses[name].icon ? ( // eslint-disable-line no-nested-ternary
+                          Array.isArray(licenses[name].icon) ? (
+                            licenses[name].icon.map((icon) => <i class={`icon ${icon}`}></i>)
+                          ) : (
+                            <i class={`icon ${licenses[name].icon}`}></i>
+                          )
+                        ) : (
+                          name
+                        )}
                       </a>
                     ))}
                   </p>

--- a/src/view/widget/links.jsx
+++ b/src/view/widget/links.jsx
@@ -14,7 +14,10 @@ const { cacheComponent } = require('../../util/cache');
  *     title="Widget title"
  *     links={{
  *         'Link Name 1': '/path/to/external/site',
- *         'Link Name 2': '/path/to/external/site'
+ *         'Link Name 2': {
+ *              'link': '/path/to/external/site',
+ *              'hide_hostname': true,
+ *        }
  *     }} />
  */
 class Links extends Component {
@@ -28,18 +31,22 @@ class Links extends Component {
             <ul class="menu-list">
               {Object.keys(links).map((i) => {
                 let hostname = links[i];
-                try {
-                  hostname = new URL(hostname).hostname;
-                } catch (e) {}
+                if (typeof hostname === 'object') hostname = !hostname.hide_hostname;
+                else
+                  try {
+                    hostname = new URL(hostname).hostname;
+                  } catch (e) {}
                 return (
                   <li>
                     <a class="level is-mobile" href={links[i]} target="_blank" rel="noopener">
                       <span class="level-left">
                         <span class="level-item">{i}</span>
                       </span>
-                      <span class="level-right">
-                        <span class="level-item tag">{hostname}</span>
-                      </span>
+                      {hostname ? (
+                        <span class="level-right">
+                          <span class="level-item tag">{hostname}</span>
+                        </span>
+                      ) : null}
                     </a>
                   </li>
                 );


### PR DESCRIPTION
this PR is backward-compatible.

it makes changes to `article_licensing.jsx`, `links.jsx ` and related schemas. 

the former makes the `article.licenses.icon` supports many icons, as it's common for CC lincense to show all icons, e.g.
```yaml
article:
  licenses:
     'CC BY-NC-ND 4.0':
       icon: 
         - fab fa-creative-commons-by
         - fab fa-creative-commons-nc
         - fab fa-creative-commons-nd
       url: https://creativecommons.org/licenses/by-nc-nd/4.0/
```
and the latter fix #17 by adding a new property `hide_hostname` which is a boolean.
this PR is tested on my hexo-theme-icarus deployments (ray-eldath.me) and works really great. it may need slight CSS-ing of hexo-theme-icarus regarding icons of license.

---

BTW here's another great small improvement, appending following lines to `icarus/include/style/widget.styl` creates a very sommth experience IMHO when the toc is too long to be filled in a single page even some items are stacked:

![image](https://user-images.githubusercontent.com/7938763/108105258-5e6df780-70c7-11eb-877b-71d63f52ba26.png)

```stylus
    &#toc
        .card-content
            max-height: 94vh
            overflow-y: auto
```
