### PR TITLE
Update fontawesome from v5.12.0 to v5.15.2

### DIFF
--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -20,7 +20,7 @@ const PROVIDERS = {
   },
   ICON: {
     loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css',
-    fontawesome: 'https://use.fontawesome.com/releases/v5.15.1/css/all.css',
+    fontawesome: 'https://use.fontawesome.com/releases/v5.15.2/css/all.css',
   },
 };
 

--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -19,8 +19,8 @@ const PROVIDERS = {
     loli: 'https://fonts.loli.net/${ type }?family=${ fontname }',
   },
   ICON: {
-    loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/5.12.0/css/all.min.css',
-    fontawesome: 'https://use.fontawesome.com/releases/v5.12.0/css/all.css',
+    loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css',
+    fontawesome: 'https://use.fontawesome.com/releases/v5.15.2/css/all.css',
   },
 };
 

--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -20,7 +20,7 @@ const PROVIDERS = {
   },
   ICON: {
     loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css',
-    fontawesome: 'https://use.fontawesome.com/releases/v5.15.2/css/all.css',
+    fontawesome: 'https://use.fontawesome.com/releases/v5.15.1/css/all.css',
   },
 };
 

--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -91,7 +91,7 @@ const UNPKG_FIXTURES = {
  *
  * // Use the function below to insert FontAwesome icon font CSS URL.
  * iconcdn();
- * // -> https://use.fontawesome.com/releases/v5.12.0/css/all.css
+ * // -> https://use.fontawesome.com/releases/v5.15.2/css/all.css
  */
 module.exports = function (hexo) {
   function applyFixture(fixture, _package, version, filename) {

--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -204,7 +204,7 @@ describe('Get icon font URL', () => {
 
   test('fontawesome', () => {
     hexo.config.providers = { iconcdn: 'fontawesome' };
-    const expected = ['https://use.fontawesome.com/releases/v5.12.0/css/all.css'];
+    const expected = ['https://use.fontawesome.com/releases/v5.15.2/css/all.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 

--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -210,7 +210,7 @@ describe('Get icon font URL', () => {
 
   test('loli', () => {
     hexo.config.providers = { iconcdn: 'loli' };
-    const expected = ['https://cdnjs.loli.net/ajax/libs/font-awesome/5.12.0/css/all.min.css'];
+    const expected = ['https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11422478/108524999-9a44cf00-730a-11eb-8fd2-ec5d587e2bfe.png)


Fontawesome v5.12.0 cannot pass [PageSpeed](https://developers.google.com/speed/pagespeed/insights/), and the issue ([ref1](https://github.com/FortAwesome/Font-Awesome/issues/14387), [ref2](https://github.com/FortAwesome/Font-Awesome/issues/15085)) has been fixed after v5.13.0 ([ref](https://github.com/FortAwesome/Font-Awesome/issues/16077)). 
It'll we great if this plugin can update the fontawesome version.
