### PR TITLE
make tags widget configurable from _config.icarus.yml

### DIFF
--- a/src/schema/widget/tags.json
+++ b/src/schema/widget/tags.json
@@ -7,6 +7,23 @@
     "type": {
       "type": "string",
       "const": "tags"
+    },
+    "order_by": {
+      "type": "string",
+      "default": "name",
+      "description": "How to order tags. For example 'name' to order by name in ascending order, and '-length' to order by number of posts in each tags in descending order",
+      "nullable": true
+    },
+    "amount": {
+      "type": "integer",
+      "description": "Amount of tags to show. Will show all if not set.",
+      "nullable": true
+    },
+    "show_count": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to show tags count, i.e. number of posts in the tag.",
+      "nullable": true
     }
   },
   "required": ["type"]

--- a/src/view/widget/tags.jsx
+++ b/src/view/widget/tags.jsx
@@ -22,7 +22,7 @@ const { cacheComponent } = require('../../util/cache');
  */
 class Tags extends Component {
   render() {
-    const { tags, title, show_count } = this.props;
+    const { tags, title, showCount } = this.props;
 
     return (
       <div class="card widget" data-type="tags">
@@ -34,7 +34,7 @@ class Tags extends Component {
                 <div class="control">
                   <a class="tags has-addons" href={tag.url}>
                     <span class="tag">{tag.name}</span>
-                    {show_count ? <span class="tag">{tag.count}</span> : null}
+                    {showCount ? <span class="tag">{tag.count}</span> : null}
                   </a>
                 </div>
               ))}
@@ -84,7 +84,7 @@ Tags.Cacheable = cacheComponent(Tags, 'widget.tags', (props) => {
   }
 
   return {
-    show_count,
+    showCount: show_count,
     title: _p('common.tag', Infinity),
     tags: tags.map((tag) => ({
       name: tag.name,

--- a/src/view/widget/tags.jsx
+++ b/src/view/widget/tags.jsx
@@ -22,7 +22,7 @@ const { cacheComponent } = require('../../util/cache');
  */
 class Tags extends Component {
   render() {
-    const { tags, title, showCount } = this.props;
+    const { tags, title, show_count } = this.props;
 
     return (
       <div class="card widget" data-type="tags">
@@ -34,7 +34,7 @@ class Tags extends Component {
                 <div class="control">
                   <a class="tags has-addons" href={tag.url}>
                     <span class="tag">{tag.name}</span>
-                    {showCount ? <span class="tag">{tag.count}</span> : null}
+                    {show_count ? <span class="tag">{tag.count}</span> : null}
                   </a>
                 </div>
               ))}
@@ -62,13 +62,15 @@ class Tags extends Component {
  *         _p: function() {...}
  *     }}
  *     tags={{...}}
- *     orderBy="name"
- *     order={1}
- *     amount={100}
- *     showCount={true} />
+ *     widget={{
+ *       order_by: "name",
+ *       amount: 100,
+ *       show_count: true
+ *     }} />
  */
 Tags.Cacheable = cacheComponent(Tags, 'widget.tags', (props) => {
-  const { helper, orderBy = 'name', order = 1, amount, showCount = true } = props;
+  const { helper, widget = {} } = props;
+  const { order_by = 'name', amount, show_count = true } = widget;
   let tags = props.tags || props.site.tags;
   const { url_for, _p } = helper;
 
@@ -76,13 +78,13 @@ Tags.Cacheable = cacheComponent(Tags, 'widget.tags', (props) => {
     return null;
   }
 
-  tags = tags.sort(orderBy, order).filter((tag) => tag.length);
+  tags = tags.sort(order_by).filter((tag) => tag.length);
   if (amount) {
     tags = tags.limit(amount);
   }
 
   return {
-    showCount,
+    show_count,
     title: _p('common.tag', Infinity),
     tags: tags.map((tag) => ({
       name: tag.name,


### PR DESCRIPTION
This PR allows users to configure the `tags` widget in `_config.icarus.yml` like this, similar to the `toc` widget:
```
    -
        position: left
        type: toc
        index: false
        collapsed: false
        depth: 3  # show up to h3
    -
        position: left
        type: tags
        order_by: "-length"
```
With the above config, it renders like this:
![2022-05-19_04-08](https://user-images.githubusercontent.com/1381301/169279880-481f9eaa-7d96-498b-9ee4-638c56e3ea5e.png)

Note that the tags in the widget are now sorted accordingly. Meanwhile, the body of `/tags` page still works and its content remains unchanged (it would be good to change it accordingly as well, but that's out of the scope of this PR).


This PR follows what's done in https://github.com/ppoffice/hexo-component-inferno/commit/08dd85fa049e02bee9880ad26f2e8f4bb66e882d.

