### PR TITLE
Add 'prepare' script to package.json to allow install from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format-check": "npm run _format -- --check",
     "docs": "jsdoc src/**/* -d doc -t node_modules/minami",
     "build": "babel src --out-dir lib && cp -r src/schema lib/schema",
-    "clean": "rm -rf lib doc coverage"
+    "clean": "rm -rf lib doc coverage",
+    "prepare": "npm run build"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
`npm i git@github.com:ppoffice/hexo-component-inferno.git` currently does not work: it succeeds, but will not build anything.
Adding a prepare script can make this work. This can be verified by 
`npm i git@github.com:ppwwyyxx/hexo-component-inferno.git`.

See https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts:
```
prepare (since npm@4.0.0)

Runs any time before the package is packed, i.e. during npm publish and npm pack

Runs BEFORE the package is packed

Runs BEFORE the package is published

Runs on local npm install without any arguments

Run AFTER prepublish, but BEFORE prepublishOnly

NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.
```