### PR TITLE
Update Bytedance CDN and bump FontAwsome to the 6.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ yarn.lock
 # Built files
 lib/
 doc/
+
+# macOS
+.DS_Store

--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -15,7 +15,8 @@ const PROVIDERS = {
     unpkg: 'https://unpkg.com/${ package }@${ version }/${ filename }',
     bootcdn: '[cdnjs]https://cdn.bootcdn.net/ajax/libs/${ package }/${ version }/${ filename }',
     '75cdn': '[cdnjs]https://lib.baomitu.com/${ package }/${ version }/${ filename }',
-    bytedance: '[cdnjs]https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/${package}/${version}/${filename}',
+    bytedance:
+      '[cdnjs]https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/${package}/${version}/${filename}',
   },
   FONT: {
     google: 'https://fonts.googleapis.com/${ type }?family=${ fontname }',
@@ -28,8 +29,8 @@ const PROVIDERS = {
     fontawesome: 'https://use.fontawesome.com/releases/v6.0.0/css/all.css',
     bootcdn: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/6.0.0/css/all.min.css',
     '75cdn': 'https://lib.baomitu.com/font-awesome/6.0.0/css/all.min.css',
-    bytedance: 'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css',
-
+    bytedance:
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css',
   },
 };
 

--- a/src/hexo/helper/cdn.js
+++ b/src/hexo/helper/cdn.js
@@ -15,6 +15,7 @@ const PROVIDERS = {
     unpkg: 'https://unpkg.com/${ package }@${ version }/${ filename }',
     bootcdn: '[cdnjs]https://cdn.bootcdn.net/ajax/libs/${ package }/${ version }/${ filename }',
     '75cdn': '[cdnjs]https://lib.baomitu.com/${ package }/${ version }/${ filename }',
+    bytedance: '[cdnjs]https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/${package}/${version}/${filename}',
   },
   FONT: {
     google: 'https://fonts.googleapis.com/${ type }?family=${ fontname }',
@@ -23,10 +24,12 @@ const PROVIDERS = {
     ustc: 'https://fonts.lug.ustc.edu.cn/${ type }?family=${ fontname }',
   },
   ICON: {
-    loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css',
-    fontawesome: 'https://use.fontawesome.com/releases/v5.15.2/css/all.css',
-    bootcdn: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/5.15.3/css/all.min.css',
-    '75cdn': 'https://lib.baomitu.com/font-awesome/5.12.1/css/all.min.css',
+    loli: 'https://cdnjs.loli.net/ajax/libs/font-awesome/6.0.0/css/all.min.css',
+    fontawesome: 'https://use.fontawesome.com/releases/v6.0.0/css/all.css',
+    bootcdn: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/6.0.0/css/all.min.css',
+    '75cdn': 'https://lib.baomitu.com/font-awesome/6.0.0/css/all.min.css',
+    bytedance: 'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css',
+
   },
 };
 

--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -316,7 +316,9 @@ describe('Get icon font URL', () => {
 
   test('bytedance', () => {
     hexo.config.providers = { iconcdn: 'bytedance' };
-    const expected = ['https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css'];
+    const expected = [
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css',
+    ];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 

--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -159,6 +159,27 @@ describe('Get JavaScript library URL', () => {
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 
+  test('bytedance', () => {
+    hexo.config.providers = { cdn: 'bytedance' };
+    const expected = [
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/jquery/3.0.0/jquery.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/moment.js/2.24.0/moment.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/outdated-browser/1.1.5/outdatedbrowser.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/highlight.js/9.18.1/styles/a11y-dark.min.css',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/mathjax/2.7.6/MathJax.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/pace/1.0.2/pace.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.11.1/katex.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/clipboard.js/2.0.6/clipboard.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/disqusjs/1.2.6/disqus.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/algoliasearch/4.0.3/algoliasearch-lite.umd.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/instantsearch.js/4.3.1/instantsearch.production.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/cookieconsent/3.1.1/cookieconsent.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/waline/1.5.4/Waline.min.js',
+      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/example/1.0.0/example.js',
+    ];
+    cases.forEach((func, i) => expect(func()).toBe(expected[i]));
+  });
+
   test('Custom CDN', () => {
     hexo.config.providers = { cdn: 'https://my.cdn/${ package }@${ version }/${ filename }' };
     const expected = [
@@ -271,25 +292,31 @@ describe('Get icon font URL', () => {
 
   test('fontawesome', () => {
     hexo.config.providers = { iconcdn: 'fontawesome' };
-    const expected = ['https://use.fontawesome.com/releases/v5.15.2/css/all.css'];
+    const expected = ['https://use.fontawesome.com/releases/v6.0.0/css/all.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 
   test('loli', () => {
     hexo.config.providers = { iconcdn: 'loli' };
-    const expected = ['https://cdnjs.loli.net/ajax/libs/font-awesome/5.15.2/css/all.min.css'];
+    const expected = ['https://cdnjs.loli.net/ajax/libs/font-awesome/6.0.0/css/all.min.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 
   test('bootcdn', () => {
     hexo.config.providers = { iconcdn: 'bootcdn' };
-    const expected = ['https://cdn.bootcdn.net/ajax/libs/font-awesome/5.15.3/css/all.min.css'];
+    const expected = ['https://cdn.bootcdn.net/ajax/libs/font-awesome/6.0.0/css/all.min.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 
   test('75cdn', () => {
     hexo.config.providers = { iconcdn: '75cdn' };
-    const expected = ['https://lib.baomitu.com/font-awesome/5.12.1/css/all.min.css'];
+    const expected = ['https://lib.baomitu.com/font-awesome/6.0.0/css/all.min.css'];
+    cases.forEach((func, i) => expect(func()).toBe(expected[i]));
+  });
+
+  test('bytedance', () => {
+    hexo.config.providers = { iconcdn: 'bytedance' };
+    const expected = ['https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/font-awesome/6.0.0/css/all.min.css'];
     cases.forEach((func, i) => expect(func()).toBe(expected[i]));
   });
 

--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -170,7 +170,7 @@ describe('Get JavaScript library URL', () => {
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/pace/1.0.2/pace.min.js',
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/KaTeX/0.11.1/katex.min.js',
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/clipboard.js/2.0.6/clipboard.min.js',
-      'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/disqusjs/1.2.6/disqus.min.js',
+      'https://cdn.jsdelivr.net/npm/disqusjs@1.2.6/dist/disqus.min.js',
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/algoliasearch/4.0.3/algoliasearch-lite.umd.js',
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/instantsearch.js/4.3.1/instantsearch.production.min.js',
       'https://lf3-cdn-tos.bytecdntp.com/cdn/expire-1-M/cookieconsent/3.1.1/cookieconsent.min.js',


### PR DESCRIPTION
By the way, the ustc fontapi mirror is now unavailable, it will **redirect** to the origin Google Font Api.