### PR TITLE
fix(view): cannot specify “type” of archives widget

### DIFF
--- a/src/view/widget/archives.jsx
+++ b/src/view/widget/archives.jsx
@@ -77,14 +77,14 @@ class Archives extends Component {
  *         url_for: function() {...},
  *         _p: function() {...}
  *     }}
- *     type="monthly"
+ *     group_by="monthly"
  *     order={-1}
  *     showCount={true}
  *     format="MMMM YYYY" />
  */
 Archives.Cacheable = cacheComponent(Archives, 'widget.archives', (props) => {
   const { site, config, page, helper, widget } = props;
-  const { type = 'monthly', order = -1, showCount = true, format = null } = widget;
+  const { group_by = 'monthly', order = -1, showCount = true, format = null } = widget;
 
   const { url_for, _p } = helper;
   const posts = site.posts.sort('date', order);
@@ -110,7 +110,7 @@ Archives.Cacheable = cacheComponent(Archives, 'widget.archives', (props) => {
 
     const year = date.year();
     const month = date.month() + 1;
-    const name = date.format(format || (type === 'monthly' ? 'MMMM YYYY' : 'YYYY'));
+    const name = date.format(format || (group_by === 'monthly' ? 'MMMM YYYY' : 'YYYY'));
     const lastData = data[length - 1];
 
     if (!lastData || lastData.name !== name) {
@@ -128,7 +128,7 @@ Archives.Cacheable = cacheComponent(Archives, 'widget.archives', (props) => {
   const link = (item) => {
     let url = `${config.archive_dir}/${item.year}/`;
 
-    if (type === 'monthly') {
+    if (group_by === 'monthly') {
       if (item.month < 10) url += '0';
       url += `${item.month}/`;
     }


### PR DESCRIPTION
`widget.type` should always be `"archives"` here, we cannot specify the “type” of archives widget in `_config.icarus.yml`

```yml
widgets:
    -
        position: left
        type: archives
        type: monthly # BAD
        format: 'YYYY年M月'
```

so I change "type" to "group_by"

```yml
widgets:
    -
        position: left
        type: archives
        group_by: monthly # GOOD
        format: 'YYYY年M月'
```
