### PR TITLE
feat(*): update waline comment plugin to 3.3.0

### DIFF
--- a/src/hexo/helper/cdn.test.js
+++ b/src/hexo/helper/cdn.test.js
@@ -29,7 +29,7 @@ describe('Get JavaScript library URL', () => {
       () => cdn('algoliasearch', '4.0.3', 'dist/algoliasearch-lite.umd.js'),
       () => cdn('instantsearch.js', '4.3.1', 'dist/instantsearch.production.min.js'),
       () => cdn('cookieconsent', '3.1.1', 'build/cookieconsent.min.js'),
-      () => cdn('@waline/client', '2.6.3', 'dist/waline.js'),
+      () => cdn('@waline/client', '3.3.0', 'dist/waline.js'),
       () => cdn('twikoo', '1.6.30', 'dist/twikoo.all.min.js'),
       () => cdn('example', '1.0.0', 'example.js'),
     ];
@@ -49,7 +49,7 @@ describe('Get JavaScript library URL', () => {
       'https://cdn.jsdelivr.net/npm/algoliasearch@4.0.3/dist/algoliasearch-lite.umd.js',
       'https://cdn.jsdelivr.net/npm/instantsearch.js@4.3.1/dist/instantsearch.production.min.js',
       'https://cdn.jsdelivr.net/npm/cookieconsent@3.1.1/build/cookieconsent.min.js',
-      'https://cdn.jsdelivr.net/npm/@waline/client@2.6.3/dist/waline.js',
+      'https://cdn.jsdelivr.net/npm/@waline/client@3.3.0/dist/waline.js',
       'https://cdn.jsdelivr.net/npm/twikoo@1.6.30/dist/twikoo.all.min.js',
       'https://cdn.jsdelivr.net/npm/example@1.0.0/example.js',
     ];
@@ -71,7 +71,7 @@ describe('Get JavaScript library URL', () => {
       'https://unpkg.com/algoliasearch@4.0.3/dist/algoliasearch-lite.umd.js',
       'https://unpkg.com/instantsearch.js@4.3.1/dist/instantsearch.production.min.js',
       'https://unpkg.com/cookieconsent@3.1.1/build/cookieconsent.min.js',
-      'https://unpkg.com/@waline/client@2.6.3/dist/waline.js',
+      'https://unpkg.com/@waline/client@3.3.0/dist/waline.js',
       'https://unpkg.com/twikoo@1.6.30/dist/twikoo.all.min.js',
       'https://unpkg.com/example@1.0.0/example.js',
     ];
@@ -93,7 +93,7 @@ describe('Get JavaScript library URL', () => {
       'https://cdnjs.cloudflare.com/ajax/libs/algoliasearch/4.0.3/algoliasearch-lite.umd.js',
       'https://cdnjs.cloudflare.com/ajax/libs/instantsearch.js/4.3.1/instantsearch.production.min.js',
       'https://cdnjs.cloudflare.com/ajax/libs/cookieconsent/3.1.1/cookieconsent.min.js',
-      'https://cdnjs.cloudflare.com/ajax/libs/waline/2.6.3/waline.js',
+      'https://cdnjs.cloudflare.com/ajax/libs/waline/3.3.0/waline.js',
       'https://cdnjs.cloudflare.com/ajax/libs/twikoo/1.6.30/twikoo.all.min.js',
       'https://cdnjs.cloudflare.com/ajax/libs/example/1.0.0/example.js',
     ];
@@ -115,7 +115,7 @@ describe('Get JavaScript library URL', () => {
       'https://cdnjs.loli.net/ajax/libs/algoliasearch/4.0.3/algoliasearch-lite.umd.js',
       'https://cdnjs.loli.net/ajax/libs/instantsearch.js/4.3.1/instantsearch.production.min.js',
       'https://cdnjs.loli.net/ajax/libs/cookieconsent/3.1.1/cookieconsent.min.js',
-      'https://cdnjs.loli.net/ajax/libs/waline/2.6.3/waline.js',
+      'https://cdnjs.loli.net/ajax/libs/waline/3.3.0/waline.js',
       'https://cdnjs.loli.net/ajax/libs/twikoo/1.6.30/twikoo.all.min.js',
       'https://cdnjs.loli.net/ajax/libs/example/1.0.0/example.js',
     ];
@@ -137,7 +137,7 @@ describe('Get JavaScript library URL', () => {
       'https://my.cdn/algoliasearch@4.0.3/dist/algoliasearch-lite.umd.js',
       'https://my.cdn/instantsearch.js@4.3.1/dist/instantsearch.production.min.js',
       'https://my.cdn/cookieconsent@3.1.1/build/cookieconsent.min.js',
-      'https://my.cdn/@waline/client@2.6.3/dist/waline.js',
+      'https://my.cdn/@waline/client@3.3.0/dist/waline.js',
       'https://my.cdn/twikoo@1.6.30/dist/twikoo.all.min.js',
       'https://my.cdn/example@1.0.0/example.js',
     ];
@@ -161,7 +161,7 @@ describe('Get JavaScript library URL', () => {
       'https://my.cdn/ajax/libs/algoliasearch/4.0.3/algoliasearch-lite.umd.js',
       'https://my.cdn/ajax/libs/instantsearch.js/4.3.1/instantsearch.production.min.js',
       'https://my.cdn/ajax/libs/cookieconsent/3.1.1/cookieconsent.min.js',
-      'https://my.cdn/ajax/libs/waline/2.6.3/waline.js',
+      'https://my.cdn/ajax/libs/waline/3.3.0/waline.js',
       'https://my.cdn/ajax/libs/twikoo/1.6.30/twikoo.all.min.js',
       'https://my.cdn/ajax/libs/example/1.0.0/example.js',
     ];

--- a/src/view/comment/waline.jsx
+++ b/src/view/comment/waline.jsx
@@ -64,7 +64,8 @@ class Waline extends Component {
         </div>
       );
     }
-    const js = `Waline.init({
+    const js = `import { init } from "${jsUrl}";
+        init({
             el: '#waline-thread',
             serverURL: ${JSON.stringify(serverURL)},
             path: ${path},
@@ -89,8 +90,7 @@ class Waline extends Component {
       <>
         <div id="waline-thread" class="content"></div>
         <link rel="stylesheet" href={cssUrl} />
-        <script src={jsUrl}></script>
-        <script dangerouslySetInnerHTML={{ __html: js }}></script>
+        <script type="module" dangerouslySetInnerHTML={{ __html: js }} />
       </>
     );
   }
@@ -149,8 +149,8 @@ Waline.Cacheable = cacheComponent(Waline, 'comment.waline', (props) => {
     pageview: comment.pageview,
     comment: comment.comment,
     copyright: comment.copyright,
-    jsUrl: helper.cdn('@waline/client', '2.6.3', 'dist/waline.js'),
-    cssUrl: helper.cdn('@waline/client', '2.6.3', 'dist/waline.css'),
+    jsUrl: helper.cdn('@waline/client', '3.3.0', 'dist/waline.js'),
+    cssUrl: helper.cdn('@waline/client', '3.3.0', 'dist/waline.css'),
   };
 });
 


### PR DESCRIPTION
Most CDN providers have not updated to the latest version  2.5.1, so I choose 2.3.0