### PR TITLE
feat(view): load lightgallery plugin

### DIFF
--- a/src/view/plugin/gallery.jsx
+++ b/src/view/plugin/gallery.jsx
@@ -73,7 +73,7 @@ Gallery.Cacheable = cacheComponent(Gallery, 'plugin.gallery', (props) => {
   return {
     head,
     lightGallery: {
-      jsUrl: helper.cdn('lightgallery', '1.10.0', 'dist/js/lightgallery.min.js'),
+      jsUrl: helper.cdn('lightgallery', '1.10.0', 'dist/js/lightgallery-all.min.js'),
       cssUrl: helper.cdn('lightgallery', '1.10.0', 'dist/css/lightgallery.min.css'),
     },
     justifiedGallery: {


### PR DESCRIPTION
`lightgallery.min.js`:
![image](https://github.com/user-attachments/assets/8fda1f12-fd79-423a-af22-e17760ce667f)

`lightgallery-all.min.js`:
![image](https://github.com/user-attachments/assets/26bd7b2e-2038-421b-9a60-35aa069f7e9e)