### PR TITLE
Allow users to customize excerpt field for Algolia search

### DIFF
--- a/asset/js/algolia.js
+++ b/asset/js/algolia.js
@@ -8,7 +8,7 @@ function loadAlgolia(config, translation) {
 
   search.addWidgets([
     instantsearch.widgets.configure({
-      attributesToSnippet: ['excerpt'],
+      attributesToSnippet: [config.excerpt],
     }),
   ]);
 
@@ -47,7 +47,7 @@ function loadAlgolia(config, translation) {
         },
         item: function (hit) {
           let title = instantsearch.highlight({ attribute: 'title', hit });
-          let excerpt = instantsearch.highlight({ attribute: 'excerpt', hit });
+          let excerpt = instantsearch.highlight({ attribute: config.excerpt, hit });
           title = title ? title : translation.untitled;
           excerpt = excerpt
             .replace(new RegExp('<em>', 'ig'), '[algolia-highlight]')

--- a/src/schema/search/algolia.json
+++ b/src/schema/search/algolia.json
@@ -7,6 +7,10 @@
     "type": {
       "type": "string",
       "const": "algolia"
+    },
+    "excerpt": {
+      "type": "string",
+      "description": "The field name to be used as the excerpt in the Algolia index. Defaults to 'excerpt'."
     }
   },
   "required": ["type"]

--- a/src/view/search/algolia.jsx
+++ b/src/view/search/algolia.jsx
@@ -31,6 +31,7 @@ class Algolia extends Component {
       applicationId,
       apiKey,
       indexName,
+      excerpt,
       jsUrl,
       algoliaSearchUrl,
       instantSearchUrl,
@@ -45,7 +46,7 @@ class Algolia extends Component {
       );
     }
 
-    const config = { applicationId, apiKey, indexName };
+    const config = { applicationId, apiKey, indexName, excerpt };
     const js = `document.addEventListener('DOMContentLoaded', function () {
             loadAlgolia(${JSON.stringify(config)}, ${JSON.stringify(translation)});
         });`;
@@ -99,7 +100,7 @@ class Algolia extends Component {
  *     }} />
  */
 Algolia.Cacheable = cacheComponent(Algolia, 'search.algolia', (props) => {
-  const { config, helper } = props;
+  const { config, helper, search } = props;
   const { algolia } = config;
 
   return {
@@ -112,6 +113,7 @@ Algolia.Cacheable = cacheComponent(Algolia, 'search.algolia', (props) => {
     applicationId: algolia ? algolia.applicationID : null,
     apiKey: algolia ? algolia.apiKey : null,
     indexName: algolia ? algolia.indexName : null,
+    excerpt: search.excerpt ? search.excerpt : 'excerpt',
     algoliaSearchUrl: helper.cdn('algoliasearch', '4.0.3', 'dist/algoliasearch-lite.umd.js'),
     instantSearchUrl: helper.cdn(
       'instantsearch.js',


### PR DESCRIPTION
- Updated algolia.json schema.
- Modified the search integration to use the custom excerpt field if specified.
- Fallback to 'excerpt' if no custom field is provided.