### PR TITLE
ensure clicking on searchbox-mask closes the searchbox

### DIFF
--- a/src/view/search/algolia.jsx
+++ b/src/view/search/algolia.jsx
@@ -54,6 +54,9 @@ class Algolia extends Component {
     return (
       <>
         <div class="searchbox">
+          <div
+            class="searchbox-mask"
+            style="position:absolute;bottom:0px;left:0px;right:0px;top:0px;"></div>
           <div class="searchbox-container">
             <div class="searchbox-header">
               <div class="searchbox-input-container" id="algolia-input"></div>

--- a/src/view/search/baidu.jsx
+++ b/src/view/search/baidu.jsx
@@ -36,6 +36,9 @@ class Baidu extends Component {
     return (
       <>
         <div class="searchbox">
+          <div
+            class="searchbox-mask"
+            style="position:absolute;bottom:0px;left:0px;right:0px;top:0px;"></div>
           <div class="searchbox-container">
             <div class="searchbox-header">
               <form class="searchbox-input-container">

--- a/src/view/search/google_cse.jsx
+++ b/src/view/search/google_cse.jsx
@@ -35,6 +35,9 @@ class GoogleCSE extends Component {
       <>
         <style dangerouslySetInnerHTML={{ __html: css }}></style>
         <div class="searchbox">
+          <div
+            class="searchbox-mask"
+            style="position:absolute;bottom:0px;left:0px;right:0px;top:0px;"></div>
           <div class="searchbox-container">
             <div class="searchbox-header">
               <div class="searchbox-input-container">


### PR DESCRIPTION
In `asset/js/algolia.js`, there is an event listener that closes the searchbox when `.searchbox .searchbox-mask` is clicked:

```js
  .on('click', '.searchbox .searchbox-mask', () => {
    $('.searchbox').removeClass('show');
  });
```

However, in `src/view/search/algolia.jsx`, the rendered searchbox was missing the `.searchbox-mask` element. This commit adds the missing element to ensure the click-to-close functionality works properly.

Additionally, the style for `.searchbox-mask` is currently written inline within the component. For better maintainability and style management, I suggest moving it to the theme's stylesheet file: `hexo-theme-icarus/include/style/search.styl`.

If you'd prefer to have the styles in the .styl file, I’d be happy to update both the JSX and .styl files and resubmit the pull request.